### PR TITLE
fix(uwsgi): Fix broken uWSGI config (#237)

### DIFF
--- a/sentry.conf.py
+++ b/sentry.conf.py
@@ -259,9 +259,14 @@ if env('SENTRY_USE_SSL', False):
 SENTRY_WEB_HOST = '0.0.0.0'
 SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {
+    'http': '%s:%s' % (SENTRY_WEB_HOST, SENTRY_WEB_PORT),
+    'protocol': 'uwsgi',
+    # This is need to prevent https://git.io/fj7Lw
+    'uwsgi-socket': None,
+    'http-keepalive': True,
+    'memory-report': False,
     # 'workers': 3,  # the number of web workers
 }
-
 
 
 ##########


### PR DESCRIPTION
This patch introduces the following fixes to uWSGI config which
was not set up correctly to be used publicly (not behind a router,
load balancer, proxy like nginx etc.):

 - Use `http` option for a front-proxy
 - Set protocol back to `uwsgi` due to above
 - Prevent forced socket binding to `uwsgi` due to protocol change
 above (https://git.io/fj7Lw)
 - Turn on "keep-alive" support

Should fix getsentry/sentry-cli#40.